### PR TITLE
temporarily fix compilation on linux

### DIFF
--- a/newlib/src/libgloss/eduos/Makefile.in
+++ b/newlib/src/libgloss/eduos/Makefile.in
@@ -115,9 +115,11 @@ dup.o: $(srcdir)/dup.c
 dup2.o: $(srcdir)/dup2.c
 
 install: $($(CPU)_INSTALL)
+	mkdir -p  $(DESTDIR)$(tooldir)/lib${MULTISUBDIR}
 	$(INSTALL_DATA) $(CRT0) $(DESTDIR)$(tooldir)/lib${MULTISUBDIR}/crt0.o
 	$(INSTALL_DATA) $(EDUOS_BSP) $(DESTDIR)$(tooldir)/lib${MULTISUBDIR}/$(EDUOS_BSP)
 	$(INSTALL_DATA) ${srcdir}/link$(BIT).ld $(DESTDIR)$(tooldir)/lib${MULTISUBDIR}/link.ld
+	mkdir -p ${DESTDIR}${tooldir}/include/sys
 	for i in ${srcdir}/include/sys/*.h; do \
 	 ${INSTALL_DATA} $$i ${DESTDIR}${tooldir}/include/sys/`basename $$i`; \
 	done;

--- a/newlib/src/newlib/libc/include/sys/config.h
+++ b/newlib/src/newlib/libc/include/sys/config.h
@@ -94,7 +94,7 @@
 #define HAVE_GETDATE
 #define _HAVE_SYSTYPES
 #define _READ_WRITE_RETURN_TYPE _ssize_t
-#define __LARGE64_FILES 1
+/* #define __LARGE64_FILES 1 */
 /* we use some glibc header files so turn on glibc large file feature */
 #define _LARGEFILE64_SOURCE 1
 #endif


### PR DESCRIPTION
```bash
mkdir -p $(DESTDIR)$(tooldir)/lib${MULTISUBDIR}
mkdir -p ${DESTDIR}${tooldir}/include/sys
```

was needed because at the time of execution, the destination directory didn't exist yet. I have no idea why this differs on Mac OS but it fixes linking issues not finding 'link.ld'.

Secondly I had to disable large file support because of linker errors not finding symbols `__swrite64` and `__sseek64` while linking examples. Apparently these functions are defined in `newlib/libc/stdio64/`, but this directory won't be compiled neither on my linux machine nor on Mac OS. Again, I have no clue why this works as is on Mac OS.